### PR TITLE
Show no token UI if auth token was set to an empty value in .env file

### DIFF
--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -8,13 +8,22 @@ const state = reactive({
 export const useMenuItems = () => {
   const items = ref([]);
   const loading = ref(true);
-  butterCMS?.content
-    .retrieve(["navigation_menu"])
-    .then((response) => {
-      items.value = response.data.data.navigation_menu[0].menu_items;
-    })
-    .catch((e) => (state.error = e))
-    .finally(() => (loading.value = false));
+
+  if (!butterCMS) {
+    // if for some reason Butter instance ahs not been initialized
+    // for example, if auth token was not provided
+    // loading should be false
+    loading.value = false;
+  } else {
+    butterCMS.content
+      .retrieve(["navigation_menu"])
+      .then((response) => {
+        items.value = response.data.data.navigation_menu[0].menu_items;
+      })
+      .catch((e) => (state.error = e))
+      .finally(() => (loading.value = false));
+  }
+
   return { items, loading };
 };
 


### PR DESCRIPTION
How to test: Set `VITE_APP_BUTTER_CMS_API_KEY` to empty string in the `.env` file. The app should show a no token screen instead of inifinte spinner https://www.notion.so/No-user-feedback-when-API-key-is-missing-1f1bb9a672328058a6a6d9eee6cf779b?d=1febb9a6723280e6a2ab001c47a104dc

https://tiugotech.atlassian.net/browse/BCMS-750